### PR TITLE
Fix extra space in embed_query

### DIFF
--- a/src/embeddings.py
+++ b/src/embeddings.py
@@ -6,7 +6,7 @@ class LLMStudioEmbeddings(Embeddings):
         self.api_url = api_url
 
     def embed_query(self, text: str):
-        response =  requests.post(f"{self.api_url}/v1/embeddings", json={"input": text})
+        response = requests.post(f"{self.api_url}/v1/embeddings", json={"input": text})
         response_data = response.json()
         return response_data['data'][0]['embedding']
 


### PR DESCRIPTION
## Summary
- remove double space before `requests.post` in `embed_query`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e2dc416308320bb8972d01c012175