### PR TITLE
Fix CustomLLM message history

### DIFF
--- a/src/llm.py
+++ b/src/llm.py
@@ -4,7 +4,14 @@ from typing import List
 
 class CustomLLM(LLM):
     api_url: str
-    message_history: List[dict] = []
+    message_history: List[dict]
+
+    def __init__(self, api_url: str):
+        self.api_url = api_url
+        # Each instance should maintain its own history of messages. Using a
+        # list defined at the class level would result in all instances
+        # sharing the same history, so we initialise it here instead.
+        self.message_history = []
 
     def _call(self, prompt: str, stop=None) -> str:
         self.message_history.append({"role": "user", "content": prompt})


### PR DESCRIPTION
## Summary
- keep `CustomLLM` message history instance specific

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_683e28d8e6a88320a64b9ac88d9783b6