### PR TITLE
Ensure CustomLLM keeps separate histories

### DIFF
--- a/src/llm.py
+++ b/src/llm.py
@@ -4,14 +4,13 @@ from typing import List
 
 class CustomLLM(LLM):
     api_url: str
-    message_history: List[dict]
 
     def __init__(self, api_url: str):
         self.api_url = api_url
         # Each instance should maintain its own history of messages. Using a
         # list defined at the class level would result in all instances
         # sharing the same history, so we initialise it here instead.
-        self.message_history = []
+        self.message_history: List[dict] = []
 
     def _call(self, prompt: str, stop=None) -> str:
         self.message_history.append({"role": "user", "content": prompt})

--- a/tests/unit/test_llm.py
+++ b/tests/unit/test_llm.py
@@ -20,3 +20,36 @@ def test_call_updates_history(monkeypatch):
         {"role": "user", "content": "hi"},
         {"role": "assistant", "content": "hey"},
     ]
+
+
+def test_instances_have_separate_histories(monkeypatch):
+    import requests
+    from src.llm import CustomLLM
+
+    def mock_post(url, json):
+        # Always return a simple assistant response regardless of input
+        return DummyResponse({"choices": [{"message": {"content": "resp"}}]})
+
+    # Patch requests.post for the test and ensure the module under test uses it
+    monkeypatch.setattr(requests, "post", mock_post)
+    import src.llm as llm_module
+    monkeypatch.setattr(llm_module, "requests", requests, raising=False)
+
+    llm1 = CustomLLM(api_url="http://mock")
+    llm2 = CustomLLM(api_url="http://mock")
+
+    llm1._call("hello1")
+    # Only llm1 should have history at this point
+    assert llm2.message_history == []
+
+    llm2._call("hello2")
+
+    assert llm1.message_history == [
+        {"role": "user", "content": "hello1"},
+        {"role": "assistant", "content": "resp"},
+    ]
+    assert llm2.message_history == [
+        {"role": "user", "content": "hello2"},
+        {"role": "assistant", "content": "resp"},
+    ]
+    assert llm1.message_history is not llm2.message_history


### PR DESCRIPTION
## Summary
- initialize `message_history` per instance in `CustomLLM`
- test that two `CustomLLM` objects do not share history

## Testing
- `pytest -q -c /dev/null`

------
https://chatgpt.com/codex/tasks/task_b_683e445e26b4832089f0dfb271376382